### PR TITLE
fix(pullzone): pullzone purge behavior

### DIFF
--- a/src/commands/pullzone.ts
+++ b/src/commands/pullzone.ts
@@ -16,6 +16,7 @@
 import { createCdnContext } from '../cdn.js'
 import type { FailedPurgeCache, PullZonePurgeCacheResponse } from '../clients/bunny-api.js'
 import { creatBunnyApiClient } from '../clients/bunny-api.js'
+import MysteryBoxError, { Error } from '../error.js'
 import type { Config } from '../types'
 
 interface PullzoneOptions {
@@ -58,9 +59,10 @@ async function purgeCache(this: Config, opts: OptionsPurgeCache) {
   const client = creatBunnyApiClient(cdn, logger)
   const idZones = zone ? [zone] : (await client.pullZone.list()).map(({ Id }) => Id)
 
-
   return Promise.allSettled(idZones.map((id) => client.pullZone.purgeCache(id)))
     .then((responses) => {
+      let isOk = true
+      const failedZoneIds: number[] = []
       logger.table(responses
         .map((res) => {
           if (res.status === 'rejected') {
@@ -70,8 +72,26 @@ async function purgeCache(this: Config, opts: OptionsPurgeCache) {
           const { id, status } = res.value as PullZonePurgeCacheResponse
           return { id, status }
         })
-        .map(({ id, status }) => ({ idZone: id, purged: `${status === 204 ? 'Ok' : 'Error'} (${status})` }))
+        .reduce<Record<string, unknown>[]>((lines, { id, status }) => {
+          isOk = isOk && status === 204
+          if (status !== 204) {
+            failedZoneIds.push(id)
+          }
+          lines.push({ idZone: id, purged: `${status === 204 ? 'Ok' : 'Error'} (${status})` })
+          return lines
+        }, [])
       )
+
+      return isOk
+        ? Promise.resolve()
+        : Promise.reject(
+          new MysteryBoxError(
+            Error.ResponseNotOk,
+            'somthing went wrong while attempting to purge zones'
+              + `with id${failedZoneIds.length < 2 ? '' : 's'} `
+              + `${failedZoneIds.map(id => `'${String(id)}'`).join(', ')}`
+          )
+        )
     })
 }
 

--- a/src/commands/pullzone.ts
+++ b/src/commands/pullzone.ts
@@ -61,7 +61,6 @@ async function purgeCache(this: Config, opts: OptionsPurgeCache) {
 
   return Promise.allSettled(idZones.map((id) => client.pullZone.purgeCache(id)))
     .then((responses) => {
-      let isOk = true
       const failedZoneIds: number[] = []
       logger.table(responses
         .map((res) => {
@@ -73,7 +72,6 @@ async function purgeCache(this: Config, opts: OptionsPurgeCache) {
           return { id, status }
         })
         .reduce<Record<string, unknown>[]>((lines, { id, status }) => {
-          isOk = isOk && status === 204
           if (status !== 204) {
             failedZoneIds.push(id)
           }
@@ -82,7 +80,7 @@ async function purgeCache(this: Config, opts: OptionsPurgeCache) {
         }, [])
       )
 
-      return isOk
+      return failedZoneIds.length === 0
         ? Promise.resolve()
         : Promise.reject(
           new MysteryBoxError(

--- a/src/index.ts
+++ b/src/index.ts
@@ -43,7 +43,7 @@ createCommand(process.argv, globalThis, logger)
       // Catched by commander library
       return exit(1)
     } else {
-      logger.error('Unhandled error', err instanceof TypeError ? err.message : err)
+      logger.error(`Unhandled error: ${err instanceof TypeError ? err.message : err}`)
     }
 
     return exit(1)

--- a/tests/unit/commands/pullzone.test.ts
+++ b/tests/unit/commands/pullzone.test.ts
@@ -163,7 +163,7 @@ describe('pullzone purge', () => {
       expect(postApiCall).to.be.equal(2)
     })
 
-    it('should not crash if one zone fails', async function (this: Context) {
+    it('should crash if one zone fails', async function (this: Context) {
       if (this.test?.sandbox === undefined) {
         throw new TypeError('Cannot find sandbox')
       }
@@ -203,7 +203,7 @@ describe('pullzone purge', () => {
         buildCommandArguments([...baseCommand, ...baseArgs]),
         global,
         loggerStub
-      )).to.be.eventually.fulfilled
+      )).to.be.eventually.rejected
 
       expect(getApiCall).to.be.equal(1)
       expect(postApiCall).to.be.equal(2)


### PR DESCRIPTION

<!--
    Thank you for proposing this Pull Request. We ask you first to follow this template to include the information needed for a more comprehensible review.
-->

## Pull Request Type

<!-- What kind of change does this PR introduce? Please check the one that applies to this PR using "x".  -->

- [x] Bugfix

## Description

- should throw when at least one purge went wrong
- a message should be printed as `log.error` since there's a visual mismatch between the result table (all green) and the fact an error actually occurred

<!--
    Please include here a description of the Pull Request: what you are modifying, why you are proposing it, why is important..
    Feel free to link a relevant issue that might be affected by your updates.
-->